### PR TITLE
Fixes the case where response decoders were unable to parse the type.

### DIFF
--- a/src/main/java/feign/error/ExceptionGenerator.java
+++ b/src/main/java/feign/error/ExceptionGenerator.java
@@ -46,11 +46,11 @@ class ExceptionGenerator {
   private final Integer bodyIndex;
   private final Integer headerMapIndex;
   private final Integer numOfParams;
-  private final Class bodyType;
+  private final Class<?> bodyType;
   private final Class<? extends Exception> exceptionType;
   private final Decoder bodyDecoder;
 
-  ExceptionGenerator(Integer bodyIndex, Integer headerMapIndex, Integer numOfParams, Class bodyType,
+  ExceptionGenerator(Integer bodyIndex, Integer headerMapIndex, Integer numOfParams, Class<?> bodyType,
       Class<? extends Exception> exceptionType, Decoder bodyDecoder) {
     this.bodyIndex = bodyIndex;
     this.headerMapIndex = headerMapIndex;
@@ -84,7 +84,7 @@ class ExceptionGenerator {
   }
 
   private Object resolveBody(Response response) {
-    if (bodyType.getClass().equals(Response.class)) {
+    if (bodyType.isInstance(response)) {
       return response;
     }
     try {
@@ -120,7 +120,7 @@ class ExceptionGenerator {
       Integer bodyIndex = -1;
       Integer headerMapIndex = -1;
       Integer numOfParams = parameterTypes.length;
-      Class bodyType = null;
+      Class<?> bodyType = null;
 
       for (int i = 0; i < parameterTypes.length; i++) {
         Annotation[] paramAnnotations = parametersAnnotations[i];

--- a/src/test/java/feign/error/AnnotationErrorDecoderExceptionConstructorsTest.java
+++ b/src/test/java/feign/error/AnnotationErrorDecoderExceptionConstructorsTest.java
@@ -73,7 +73,8 @@ public class AnnotationErrorDecoderExceptionConstructorsTest extends
         {"test Declared Constructor", 509,
             DefinedConstructorWithAnnotationForNonSupportedBody.class, NULL_BODY, NO_HEADERS},
         {"test Declared Constructor", 510,
-            DefinedConstructorWithAnnotationForOptionalBody.class, Optional.of(NON_NULL_BODY), NO_HEADERS},
+            DefinedConstructorWithAnnotationForOptionalBody.class, Optional.of(NON_NULL_BODY),
+            NO_HEADERS},
     });
   }
 


### PR DESCRIPTION
Two things were addressed here:
1) Raw response object injection.
2) Generic type information was lost during decoder delegation and decoders were unable to figure out which result type was expected.