### PR TITLE
feign.Request object now supported as exception constructor parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Any exception can be used if they have a default constructor:
 class DefaultConstructorException extends Exception {}
 ```
 
-However, if you want to have parameters (such  as the body in the error response or headers), you have to annotate its 
+However, if you want to have parameters (such  as the feign.Request object or response body or response headers), you have to annotate its 
 constructor appropriately (the body annotation is optional, provided there aren't paramters which will clash)
 
 All the following examples are valid exceptions:
@@ -97,11 +97,32 @@ class JustBody extends Exception {
 
     }
 }
+class JustRequest extends Exception {
+
+    @FeignExceptionConstructor
+    public JustRequest(Request request) {
+
+    }
+}
+class RequestAndResponseBody extends Exception {
+
+    @FeignExceptionConstructor
+    public RequestAndResponseBody(Request request, String body) {
+
+    }
+}
 //Headers must be of type Map<String, Collection<String>>
 class BodyAndHeaders extends Exception {
 
     @FeignExceptionConstructor
     public BodyAndHeaders(@ResponseBody String body, @ResponseHeaders Map<String, Collection<String>> headers) {
+
+    }
+}
+class RequestAndResponseBodyAndHeaders extends Exception {
+
+    @FeignExceptionConstructor
+    public RequestAndResponseBodyAndHeaders(Request request, @ResponseBody String body, @ResponseHeaders Map<String, Collection<String>> headers) {
 
     }
 }

--- a/src/main/java/feign/error/ExceptionGenerator.java
+++ b/src/main/java/feign/error/ExceptionGenerator.java
@@ -53,7 +53,8 @@ class ExceptionGenerator {
   private final Class<? extends Exception> exceptionType;
   private final Decoder bodyDecoder;
 
-  ExceptionGenerator(Integer bodyIndex, Integer requestIndex, Integer headerMapIndex, Integer numOfParams, Type bodyType,
+  ExceptionGenerator(Integer bodyIndex, Integer requestIndex, Integer headerMapIndex,
+      Integer numOfParams, Type bodyType,
       Class<? extends Exception> exceptionType, Decoder bodyDecoder) {
     this.bodyIndex = bodyIndex;
     this.requestIndex = requestIndex;
@@ -146,13 +147,13 @@ class ExceptionGenerator {
           }
         }
         if (!foundAnnotation) {
-          if(parameterTypes[i].equals(Request.class)) {
+          if (parameterTypes[i].equals(Request.class)) {
             checkState(requestIndex == -1,
-                    "Cannot have two parameters either without annotations or with object of type feign.Request");
+                "Cannot have two parameters either without annotations or with object of type feign.Request");
             requestIndex = i;
           } else {
             checkState(bodyIndex == -1,
-                    "Cannot have two parameters either without annotations or with @ResponseBody annotation");
+                "Cannot have two parameters either without annotations or with @ResponseBody annotation");
             bodyIndex = i;
             bodyType = parameterTypes[i];
           }

--- a/src/test/java/feign/error/AnnotationErrorDecoderExceptionConstructorsTest.java
+++ b/src/test/java/feign/error/AnnotationErrorDecoderExceptionConstructorsTest.java
@@ -21,10 +21,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 import org.junit.runners.Parameterized.Parameter;
-
 import javax.swing.text.html.Option;
 import java.util.*;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static feign.error.AnnotationErrorDecoderExceptionConstructorsTest.TestClientInterfaceWithDifferentExceptionConstructors;
 import static feign.error.AnnotationErrorDecoderExceptionConstructorsTest.TestClientInterfaceWithDifferentExceptionConstructors.*;
@@ -37,7 +35,8 @@ public class AnnotationErrorDecoderExceptionConstructorsTest extends
   private static final String NO_BODY = "NO BODY";
   private static final Object NULL_BODY = null;
   private static final String NON_NULL_BODY = "A GIVEN BODY";
-  private static final feign.Request REQUEST = feign.Request.create(feign.Request.HttpMethod.GET, "http://test", Collections.emptyMap(), null);
+  private static final feign.Request REQUEST = feign.Request.create(feign.Request.HttpMethod.GET,
+      "http://test", Collections.emptyMap(), null);
   private static final feign.Request NO_REQUEST = null;
   private static final Map<String, Collection<String>> NON_NULL_HEADERS =
       new HashMap<String, Collection<String>>();
@@ -53,44 +52,55 @@ public class AnnotationErrorDecoderExceptionConstructorsTest extends
       name = "{0}: When error code ({1}) on method ({2}) should return exception type ({3})")
   public static Iterable<Object[]> data() {
     return Arrays.asList(new Object[][] {
-        {"Test Default Constructor", 500, DefaultConstructorException.class, NO_REQUEST, NO_BODY, NO_HEADERS},
-        {"test Default Constructor", 501, DeclaredDefaultConstructorException.class, NO_REQUEST, NO_BODY,
+        {"Test Default Constructor", 500, DefaultConstructorException.class, NO_REQUEST, NO_BODY,
+            NO_HEADERS},
+        {"test Default Constructor", 501, DeclaredDefaultConstructorException.class, NO_REQUEST,
+            NO_BODY,
             NO_HEADERS},
         {"test Default Constructor", 502,
-            DeclaredDefaultConstructorWithOtherConstructorsException.class, NO_REQUEST, NO_BODY, NO_HEADERS},
-        {"test Declared Constructor", 503, DefinedConstructorWithNoAnnotationForBody.class, NO_REQUEST,
+            DeclaredDefaultConstructorWithOtherConstructorsException.class, NO_REQUEST, NO_BODY,
+            NO_HEADERS},
+        {"test Declared Constructor", 503, DefinedConstructorWithNoAnnotationForBody.class,
+            NO_REQUEST,
             NON_NULL_BODY, NO_HEADERS},
         {"test Declared Constructor", 504, DefinedConstructorWithAnnotationForBody.class,
-                NO_REQUEST, NON_NULL_BODY, NO_HEADERS},
+            NO_REQUEST, NON_NULL_BODY, NO_HEADERS},
         {"test Declared Constructor", 505, DefinedConstructorWithAnnotationForBodyAndHeaders.class,
-                NO_REQUEST, NON_NULL_BODY, NON_NULL_HEADERS},
+            NO_REQUEST, NON_NULL_BODY, NON_NULL_HEADERS},
         {"test Declared Constructor", 506,
-            DefinedConstructorWithAnnotationForBodyAndHeadersSecondOrder.class, NO_REQUEST, NON_NULL_BODY,
+            DefinedConstructorWithAnnotationForBodyAndHeadersSecondOrder.class, NO_REQUEST,
+            NON_NULL_BODY,
             NON_NULL_HEADERS},
         {"test Declared Constructor", 507, DefinedConstructorWithAnnotationForHeaders.class,
-                NO_REQUEST, NO_BODY, NON_NULL_HEADERS},
+            NO_REQUEST, NO_BODY, NON_NULL_HEADERS},
         {"test Declared Constructor", 508,
-            DefinedConstructorWithAnnotationForHeadersButNotForBody.class, NO_REQUEST, NON_NULL_BODY,
+            DefinedConstructorWithAnnotationForHeadersButNotForBody.class, NO_REQUEST,
+            NON_NULL_BODY,
             NON_NULL_HEADERS},
         {"test Declared Constructor", 509,
-            DefinedConstructorWithAnnotationForNonSupportedBody.class, NO_REQUEST, NULL_BODY, NO_HEADERS},
+            DefinedConstructorWithAnnotationForNonSupportedBody.class, NO_REQUEST, NULL_BODY,
+            NO_HEADERS},
         {"test Declared Constructor", 510,
-            DefinedConstructorWithAnnotationForOptionalBody.class, NO_REQUEST, Optional.of(NON_NULL_BODY),
+            DefinedConstructorWithAnnotationForOptionalBody.class, NO_REQUEST,
+            Optional.of(NON_NULL_BODY),
             NO_HEADERS},
         {"test Declared Constructor", 511,
-                DefinedConstructorWithRequest.class, REQUEST, NO_BODY,
-                NO_HEADERS},
+            DefinedConstructorWithRequest.class, REQUEST, NO_BODY,
+            NO_HEADERS},
         {"test Declared Constructor", 512,
-                DefinedConstructorWithRequestAndResponseBody.class, REQUEST, NON_NULL_BODY,
-                NO_HEADERS},
+            DefinedConstructorWithRequestAndResponseBody.class, REQUEST, NON_NULL_BODY,
+            NO_HEADERS},
         {"test Declared Constructor", 513,
-                DefinedConstructorWithRequestAndAnnotationForResponseBody.class, REQUEST, NON_NULL_BODY, NO_HEADERS},
+            DefinedConstructorWithRequestAndAnnotationForResponseBody.class, REQUEST, NON_NULL_BODY,
+            NO_HEADERS},
         {"test Declared Constructor", 514,
-                DefinedConstructorWithRequestAndResponseHeadersAndResponseBody.class, REQUEST, NON_NULL_BODY,
-                NON_NULL_HEADERS},
+            DefinedConstructorWithRequestAndResponseHeadersAndResponseBody.class, REQUEST,
+            NON_NULL_BODY,
+            NON_NULL_HEADERS},
         {"test Declared Constructor", 515,
-                DefinedConstructorWithRequestAndResponseHeadersAndOptionalResponseBody.class, REQUEST, Optional.of(NON_NULL_BODY),
-                NON_NULL_HEADERS}
+            DefinedConstructorWithRequestAndResponseHeadersAndOptionalResponseBody.class, REQUEST,
+            Optional.of(NON_NULL_BODY),
+            NON_NULL_HEADERS}
     });
   }
 
@@ -155,13 +165,13 @@ public class AnnotationErrorDecoderExceptionConstructorsTest extends
         @ErrorCodes(codes = {511},
             generate = DefinedConstructorWithRequest.class),
         @ErrorCodes(codes = {512},
-                generate = DefinedConstructorWithRequestAndResponseBody.class),
+            generate = DefinedConstructorWithRequestAndResponseBody.class),
         @ErrorCodes(codes = {513},
-                generate = DefinedConstructorWithRequestAndAnnotationForResponseBody.class),
+            generate = DefinedConstructorWithRequestAndAnnotationForResponseBody.class),
         @ErrorCodes(codes = {514},
-                generate = DefinedConstructorWithRequestAndResponseHeadersAndResponseBody.class),
+            generate = DefinedConstructorWithRequestAndResponseHeadersAndResponseBody.class),
         @ErrorCodes(codes = {515},
-                generate = DefinedConstructorWithRequestAndResponseHeadersAndOptionalResponseBody.class)
+            generate = DefinedConstructorWithRequestAndResponseHeadersAndOptionalResponseBody.class)
     })
     void method1Test();
 
@@ -169,7 +179,11 @@ public class AnnotationErrorDecoderExceptionConstructorsTest extends
       public Object body() {
         return NO_BODY;
       }
-      public feign.Request request() { return null; }
+
+      public feign.Request request() {
+        return null;
+      }
+
       public Map<String, Collection<String>> headers() {
         return null;
       }
@@ -282,7 +296,8 @@ public class AnnotationErrorDecoderExceptionConstructorsTest extends
       }
 
       @FeignExceptionConstructor
-      public DefinedConstructorWithRequestAndAnnotationForResponseBody(feign.Request request, @ResponseBody String body) {
+      public DefinedConstructorWithRequestAndAnnotationForResponseBody(feign.Request request,
+          @ResponseBody String body) {
         this.request = request;
         this.body = body;
       }
@@ -302,7 +317,8 @@ public class AnnotationErrorDecoderExceptionConstructorsTest extends
       }
     }
 
-    class DefinedConstructorWithRequestAndResponseHeadersAndResponseBody extends ParametersException {
+    class DefinedConstructorWithRequestAndResponseHeadersAndResponseBody
+        extends ParametersException {
       feign.Request request;
       String body;
       Map headers;
@@ -313,8 +329,8 @@ public class AnnotationErrorDecoderExceptionConstructorsTest extends
 
       @FeignExceptionConstructor
       public DefinedConstructorWithRequestAndResponseHeadersAndResponseBody(feign.Request request,
-                                                                            @ResponseHeaders Map headers,
-                                                                            @ResponseBody String body) {
+          @ResponseHeaders Map headers,
+          @ResponseBody String body) {
         this.request = request;
         this.body = body;
         this.headers = headers;
@@ -340,7 +356,8 @@ public class AnnotationErrorDecoderExceptionConstructorsTest extends
       }
     }
 
-    class DefinedConstructorWithRequestAndResponseHeadersAndOptionalResponseBody extends ParametersException {
+    class DefinedConstructorWithRequestAndResponseHeadersAndOptionalResponseBody
+        extends ParametersException {
       feign.Request request;
       Optional<String> body;
       Map headers;
@@ -350,15 +367,17 @@ public class AnnotationErrorDecoderExceptionConstructorsTest extends
       }
 
       @FeignExceptionConstructor
-      public DefinedConstructorWithRequestAndResponseHeadersAndOptionalResponseBody(feign.Request request,
-                                                                            @ResponseHeaders Map headers,
-                                                                            @ResponseBody Optional<String> body) {
+      public DefinedConstructorWithRequestAndResponseHeadersAndOptionalResponseBody(
+          feign.Request request,
+          @ResponseHeaders Map headers,
+          @ResponseBody Optional<String> body) {
         this.request = request;
         this.body = body;
         this.headers = headers;
       }
 
-      public DefinedConstructorWithRequestAndResponseHeadersAndOptionalResponseBody(TestPojo testPojo) {
+      public DefinedConstructorWithRequestAndResponseHeadersAndOptionalResponseBody(
+          TestPojo testPojo) {
         throw new UnsupportedOperationException("Should not be called");
       }
 

--- a/src/test/java/feign/error/AnnotationErrorDecoderExceptionConstructorsTest.java
+++ b/src/test/java/feign/error/AnnotationErrorDecoderExceptionConstructorsTest.java
@@ -16,15 +16,15 @@ package feign.error;
 import feign.codec.Decoder;
 import feign.optionals.OptionalDecoder;
 import org.junit.Test;
+import org.junit.runner.Request;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 import org.junit.runners.Parameterized.Parameter;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
+
+import javax.swing.text.html.Option;
+import java.util.*;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static feign.error.AnnotationErrorDecoderExceptionConstructorsTest.TestClientInterfaceWithDifferentExceptionConstructors;
 import static feign.error.AnnotationErrorDecoderExceptionConstructorsTest.TestClientInterfaceWithDifferentExceptionConstructors.*;
@@ -37,6 +37,8 @@ public class AnnotationErrorDecoderExceptionConstructorsTest extends
   private static final String NO_BODY = "NO BODY";
   private static final Object NULL_BODY = null;
   private static final String NON_NULL_BODY = "A GIVEN BODY";
+  private static final feign.Request REQUEST = feign.Request.create(feign.Request.HttpMethod.GET, "http://test", Collections.emptyMap(), null);
+  private static final feign.Request NO_REQUEST = null;
   private static final Map<String, Collection<String>> NON_NULL_HEADERS =
       new HashMap<String, Collection<String>>();
   private static final Map<String, Collection<String>> NO_HEADERS = null;
@@ -51,30 +53,44 @@ public class AnnotationErrorDecoderExceptionConstructorsTest extends
       name = "{0}: When error code ({1}) on method ({2}) should return exception type ({3})")
   public static Iterable<Object[]> data() {
     return Arrays.asList(new Object[][] {
-        {"Test Default Constructor", 500, DefaultConstructorException.class, NO_BODY, NO_HEADERS},
-        {"test Default Constructor", 501, DeclaredDefaultConstructorException.class, NO_BODY,
+        {"Test Default Constructor", 500, DefaultConstructorException.class, NO_REQUEST, NO_BODY, NO_HEADERS},
+        {"test Default Constructor", 501, DeclaredDefaultConstructorException.class, NO_REQUEST, NO_BODY,
             NO_HEADERS},
         {"test Default Constructor", 502,
-            DeclaredDefaultConstructorWithOtherConstructorsException.class, NO_BODY, NO_HEADERS},
-        {"test Declared Constructor", 503, DefinedConstructorWithNoAnnotationForBody.class,
+            DeclaredDefaultConstructorWithOtherConstructorsException.class, NO_REQUEST, NO_BODY, NO_HEADERS},
+        {"test Declared Constructor", 503, DefinedConstructorWithNoAnnotationForBody.class, NO_REQUEST,
             NON_NULL_BODY, NO_HEADERS},
         {"test Declared Constructor", 504, DefinedConstructorWithAnnotationForBody.class,
-            NON_NULL_BODY, NO_HEADERS},
+                NO_REQUEST, NON_NULL_BODY, NO_HEADERS},
         {"test Declared Constructor", 505, DefinedConstructorWithAnnotationForBodyAndHeaders.class,
-            NON_NULL_BODY, NON_NULL_HEADERS},
+                NO_REQUEST, NON_NULL_BODY, NON_NULL_HEADERS},
         {"test Declared Constructor", 506,
-            DefinedConstructorWithAnnotationForBodyAndHeadersSecondOrder.class, NON_NULL_BODY,
+            DefinedConstructorWithAnnotationForBodyAndHeadersSecondOrder.class, NO_REQUEST, NON_NULL_BODY,
             NON_NULL_HEADERS},
         {"test Declared Constructor", 507, DefinedConstructorWithAnnotationForHeaders.class,
-            NO_BODY, NON_NULL_HEADERS},
+                NO_REQUEST, NO_BODY, NON_NULL_HEADERS},
         {"test Declared Constructor", 508,
-            DefinedConstructorWithAnnotationForHeadersButNotForBody.class, NON_NULL_BODY,
+            DefinedConstructorWithAnnotationForHeadersButNotForBody.class, NO_REQUEST, NON_NULL_BODY,
             NON_NULL_HEADERS},
         {"test Declared Constructor", 509,
-            DefinedConstructorWithAnnotationForNonSupportedBody.class, NULL_BODY, NO_HEADERS},
+            DefinedConstructorWithAnnotationForNonSupportedBody.class, NO_REQUEST, NULL_BODY, NO_HEADERS},
         {"test Declared Constructor", 510,
-            DefinedConstructorWithAnnotationForOptionalBody.class, Optional.of(NON_NULL_BODY),
+            DefinedConstructorWithAnnotationForOptionalBody.class, NO_REQUEST, Optional.of(NON_NULL_BODY),
             NO_HEADERS},
+        {"test Declared Constructor", 511,
+                DefinedConstructorWithRequest.class, REQUEST, NO_BODY,
+                NO_HEADERS},
+        {"test Declared Constructor", 512,
+                DefinedConstructorWithRequestAndResponseBody.class, REQUEST, NON_NULL_BODY,
+                NO_HEADERS},
+        {"test Declared Constructor", 513,
+                DefinedConstructorWithRequestAndAnnotationForResponseBody.class, REQUEST, NON_NULL_BODY, NO_HEADERS},
+        {"test Declared Constructor", 514,
+                DefinedConstructorWithRequestAndResponseHeadersAndResponseBody.class, REQUEST, NON_NULL_BODY,
+                NON_NULL_HEADERS},
+        {"test Declared Constructor", 515,
+                DefinedConstructorWithRequestAndResponseHeadersAndOptionalResponseBody.class, REQUEST, Optional.of(NON_NULL_BODY),
+                NON_NULL_HEADERS}
     });
   }
 
@@ -88,9 +104,12 @@ public class AnnotationErrorDecoderExceptionConstructorsTest extends
   public Class<? extends Exception> expectedExceptionClass;
 
   @Parameter(3)
-  public Object expectedBody;
+  public Object expectedRequest;
 
   @Parameter(4)
+  public Object expectedBody;
+
+  @Parameter(5)
   public Map<String, Collection<String>> expectedHeaders;
 
   @Test
@@ -132,7 +151,17 @@ public class AnnotationErrorDecoderExceptionConstructorsTest extends
         @ErrorCodes(codes = {509},
             generate = DefinedConstructorWithAnnotationForNonSupportedBody.class),
         @ErrorCodes(codes = {510},
-            generate = DefinedConstructorWithAnnotationForOptionalBody.class)
+            generate = DefinedConstructorWithAnnotationForOptionalBody.class),
+        @ErrorCodes(codes = {511},
+            generate = DefinedConstructorWithRequest.class),
+        @ErrorCodes(codes = {512},
+                generate = DefinedConstructorWithRequestAndResponseBody.class),
+        @ErrorCodes(codes = {513},
+                generate = DefinedConstructorWithRequestAndAnnotationForResponseBody.class),
+        @ErrorCodes(codes = {514},
+                generate = DefinedConstructorWithRequestAndResponseHeadersAndResponseBody.class),
+        @ErrorCodes(codes = {515},
+                generate = DefinedConstructorWithRequestAndResponseHeadersAndOptionalResponseBody.class)
     })
     void method1Test();
 
@@ -140,7 +169,7 @@ public class AnnotationErrorDecoderExceptionConstructorsTest extends
       public Object body() {
         return NO_BODY;
       }
-
+      public feign.Request request() { return null; }
       public Map<String, Collection<String>> headers() {
         return null;
       }
@@ -190,6 +219,163 @@ public class AnnotationErrorDecoderExceptionConstructorsTest extends
         return body;
       }
 
+    }
+
+    class DefinedConstructorWithRequest extends ParametersException {
+      feign.Request request;
+
+      public DefinedConstructorWithRequest() {
+        throw new UnsupportedOperationException("Should not be called");
+      }
+
+      @FeignExceptionConstructor
+      public DefinedConstructorWithRequest(feign.Request request) {
+        this.request = request;
+      }
+
+      public DefinedConstructorWithRequest(TestPojo testPojo) {
+        throw new UnsupportedOperationException("Should not be called");
+      }
+
+      @Override
+      public feign.Request request() {
+        return request;
+      }
+
+    }
+
+    class DefinedConstructorWithRequestAndResponseBody extends ParametersException {
+      feign.Request request;
+      String body;
+
+      public DefinedConstructorWithRequestAndResponseBody() {
+        throw new UnsupportedOperationException("Should not be called");
+      }
+
+      @FeignExceptionConstructor
+      public DefinedConstructorWithRequestAndResponseBody(feign.Request request, String body) {
+        this.request = request;
+        this.body = body;
+      }
+
+      public DefinedConstructorWithRequestAndResponseBody(TestPojo testPojo) {
+        throw new UnsupportedOperationException("Should not be called");
+      }
+
+      @Override
+      public feign.Request request() {
+        return request;
+      }
+
+      @Override
+      public String body() {
+        return body;
+      }
+    }
+
+    class DefinedConstructorWithRequestAndAnnotationForResponseBody extends ParametersException {
+      feign.Request request;
+      String body;
+
+      public DefinedConstructorWithRequestAndAnnotationForResponseBody() {
+        throw new UnsupportedOperationException("Should not be called");
+      }
+
+      @FeignExceptionConstructor
+      public DefinedConstructorWithRequestAndAnnotationForResponseBody(feign.Request request, @ResponseBody String body) {
+        this.request = request;
+        this.body = body;
+      }
+
+      public DefinedConstructorWithRequestAndAnnotationForResponseBody(TestPojo testPojo) {
+        throw new UnsupportedOperationException("Should not be called");
+      }
+
+      @Override
+      public feign.Request request() {
+        return request;
+      }
+
+      @Override
+      public String body() {
+        return body;
+      }
+    }
+
+    class DefinedConstructorWithRequestAndResponseHeadersAndResponseBody extends ParametersException {
+      feign.Request request;
+      String body;
+      Map headers;
+
+      public DefinedConstructorWithRequestAndResponseHeadersAndResponseBody() {
+        throw new UnsupportedOperationException("Should not be called");
+      }
+
+      @FeignExceptionConstructor
+      public DefinedConstructorWithRequestAndResponseHeadersAndResponseBody(feign.Request request,
+                                                                            @ResponseHeaders Map headers,
+                                                                            @ResponseBody String body) {
+        this.request = request;
+        this.body = body;
+        this.headers = headers;
+      }
+
+      public DefinedConstructorWithRequestAndResponseHeadersAndResponseBody(TestPojo testPojo) {
+        throw new UnsupportedOperationException("Should not be called");
+      }
+
+      @Override
+      public feign.Request request() {
+        return request;
+      }
+
+      @Override
+      public Map headers() {
+        return headers;
+      }
+
+      @Override
+      public String body() {
+        return body;
+      }
+    }
+
+    class DefinedConstructorWithRequestAndResponseHeadersAndOptionalResponseBody extends ParametersException {
+      feign.Request request;
+      Optional<String> body;
+      Map headers;
+
+      public DefinedConstructorWithRequestAndResponseHeadersAndOptionalResponseBody() {
+        throw new UnsupportedOperationException("Should not be called");
+      }
+
+      @FeignExceptionConstructor
+      public DefinedConstructorWithRequestAndResponseHeadersAndOptionalResponseBody(feign.Request request,
+                                                                            @ResponseHeaders Map headers,
+                                                                            @ResponseBody Optional<String> body) {
+        this.request = request;
+        this.body = body;
+        this.headers = headers;
+      }
+
+      public DefinedConstructorWithRequestAndResponseHeadersAndOptionalResponseBody(TestPojo testPojo) {
+        throw new UnsupportedOperationException("Should not be called");
+      }
+
+      @Override
+      public feign.Request request() {
+        return request;
+      }
+
+      @Override
+      public Map headers() {
+        return headers;
+      }
+
+      @Override
+      public Object body() {
+        return body;
+      }
     }
 
     class DefinedConstructorWithAnnotationForBody extends ParametersException {

--- a/src/test/java/feign/error/AnnotationErrorDecoderIllegalInterfacesTest.java
+++ b/src/test/java/feign/error/AnnotationErrorDecoderIllegalInterfacesTest.java
@@ -15,6 +15,7 @@ package feign.error;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.Request;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
@@ -44,6 +45,8 @@ public class AnnotationErrorDecoderIllegalInterfacesTest {
             IllegalStateException.class, "Cannot generate exception - check constructor"},
         {IllegalTestClientInterfaceWithExceptionWithBadHeaderObjectParam.class,
             IllegalStateException.class, "Response Header map must be of type Map"},
+        {IllegalTestClientInterfaceWithExceptionWithTooManyRequestParams.class,
+            IllegalStateException.class, "Cannot have two parameters either without"}
     });
   }
 
@@ -105,6 +108,21 @@ public class AnnotationErrorDecoderIllegalInterfacesTest {
 
       @FeignExceptionConstructor
       public BadException(String body, @ResponseBody String otherBody) {
+
+      }
+    }
+  }
+
+  interface IllegalTestClientInterfaceWithExceptionWithTooManyRequestParams {
+    @ErrorHandling(codeSpecific = {
+            @ErrorCodes(codes = {404}, generate = BadException.class)
+    })
+    void method1Test();
+
+    class BadException extends Exception {
+
+      @FeignExceptionConstructor
+      public BadException(Request request1, Request request2) {
 
       }
     }

--- a/src/test/java/feign/error/AnnotationErrorDecoderIllegalInterfacesTest.java
+++ b/src/test/java/feign/error/AnnotationErrorDecoderIllegalInterfacesTest.java
@@ -115,7 +115,7 @@ public class AnnotationErrorDecoderIllegalInterfacesTest {
 
   interface IllegalTestClientInterfaceWithExceptionWithTooManyRequestParams {
     @ErrorHandling(codeSpecific = {
-            @ErrorCodes(codes = {404}, generate = BadException.class)
+        @ErrorCodes(codes = {404}, generate = BadException.class)
     })
     void method1Test();
 


### PR DESCRIPTION
The ExceptionGenerator now

* also looks for constructor parameter of type feign.Request.
* creates the exception providing the feign.Request by calling response.request()