### PR TITLE
More useful message for NO_DEFAULT exception out of the box.

### DIFF
--- a/src/main/java/feign/error/ErrorHandling.java
+++ b/src/main/java/feign/error/ErrorHandling.java
@@ -14,7 +14,6 @@
 package feign.error;
 
 import feign.Response;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
@@ -30,18 +29,9 @@ public @interface ErrorHandling {
   Class<? extends Exception> defaultException() default NO_DEFAULT.class;
 
   final class NO_DEFAULT extends Exception {
-
-      /**
-       * For backward compatibility.
-       */
-      @Deprecated
-      public NO_DEFAULT() {
-      }
-
-      @FeignExceptionConstructor
-      public NO_DEFAULT(@ResponseBody Response response) {
-          super("Endpoint responded with " + response.status() + ", reason: " + response.reason());
-      }
-
+    @FeignExceptionConstructor
+    public NO_DEFAULT(@ResponseBody Response response) {
+      super("Endpoint responded with " + response.status() + ", reason: " + response.reason());
+    }
   }
 }

--- a/src/main/java/feign/error/ErrorHandling.java
+++ b/src/main/java/feign/error/ErrorHandling.java
@@ -13,6 +13,8 @@
  */
 package feign.error;
 
+import feign.Response;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
@@ -28,5 +30,18 @@ public @interface ErrorHandling {
   Class<? extends Exception> defaultException() default NO_DEFAULT.class;
 
   final class NO_DEFAULT extends Exception {
+
+      /**
+       * For backward compatibility.
+       */
+      @Deprecated
+      public NO_DEFAULT() {
+      }
+
+      @FeignExceptionConstructor
+      public NO_DEFAULT(@ResponseBody Response response) {
+          super("Endpoint responded with " + response.status() + ", reason: " + response.reason());
+      }
+
   }
 }

--- a/src/test/java/feign/error/AnnotationErrorDecoderExceptionConstructorsTest.java
+++ b/src/test/java/feign/error/AnnotationErrorDecoderExceptionConstructorsTest.java
@@ -142,16 +142,16 @@ public class AnnotationErrorDecoderExceptionConstructorsTest extends
   @Test
   public void testIfExceptionIsNotInTheList() throws Exception {
     AnnotationErrorDecoder decoder = AnnotationErrorDecoder
-            .builderFor(TestClientInterfaceWithDifferentExceptionConstructors.class)
-            .withResponseBodyDecoder(new OptionalDecoder(new Decoder.Default()))
-            .build();
+        .builderFor(TestClientInterfaceWithDifferentExceptionConstructors.class)
+        .withResponseBodyDecoder(new OptionalDecoder(new Decoder.Default()))
+        .build();
 
     Exception genericException = decoder.decode(feignConfigKey("method1Test"),
-            testResponse(-1, NON_NULL_BODY, NON_NULL_HEADERS));
+        testResponse(-1, NON_NULL_BODY, NON_NULL_HEADERS));
 
     assertThat(genericException)
-            .isInstanceOf(ErrorHandling.NO_DEFAULT.class)
-            .hasMessage("Endpoint responded with -1, reason: null");
+        .isInstanceOf(ErrorHandling.NO_DEFAULT.class)
+        .hasMessage("Endpoint responded with -1, reason: null");
   }
 
   interface TestClientInterfaceWithDifferentExceptionConstructors {

--- a/src/test/java/feign/error/AnnotationErrorDecoderExceptionConstructorsTest.java
+++ b/src/test/java/feign/error/AnnotationErrorDecoderExceptionConstructorsTest.java
@@ -124,7 +124,6 @@ public class AnnotationErrorDecoderExceptionConstructorsTest extends
 
   @Test
   public void test() throws Exception {
-
     AnnotationErrorDecoder decoder = AnnotationErrorDecoder
         .builderFor(TestClientInterfaceWithDifferentExceptionConstructors.class)
         .withResponseBodyDecoder(new OptionalDecoder(new Decoder.Default()))
@@ -133,13 +132,26 @@ public class AnnotationErrorDecoderExceptionConstructorsTest extends
     Exception genericException = decoder.decode(feignConfigKey("method1Test"),
         testResponse(errorCode, NON_NULL_BODY, NON_NULL_HEADERS));
 
-    assertThat(genericException.getClass()).isEqualTo(expectedExceptionClass);
+    assertThat(genericException).isInstanceOf(expectedExceptionClass);
 
     ParametersException exception = (ParametersException) genericException;
     assertThat(exception.body()).isEqualTo(expectedBody);
     assertThat(exception.headers()).isEqualTo(expectedHeaders);
+  }
 
+  @Test
+  public void testIfExceptionIsNotInTheList() throws Exception {
+    AnnotationErrorDecoder decoder = AnnotationErrorDecoder
+            .builderFor(TestClientInterfaceWithDifferentExceptionConstructors.class)
+            .withResponseBodyDecoder(new OptionalDecoder(new Decoder.Default()))
+            .build();
 
+    Exception genericException = decoder.decode(feignConfigKey("method1Test"),
+            testResponse(-1, NON_NULL_BODY, NON_NULL_HEADERS));
+
+    assertThat(genericException)
+            .isInstanceOf(ErrorHandling.NO_DEFAULT.class)
+            .hasMessage("Endpoint responded with -1, reason: null");
   }
 
   interface TestClientInterfaceWithDifferentExceptionConstructors {


### PR DESCRIPTION
When a misconfigured error happens, NO_DEFAULT exception gives no clue on what went wrong. You have to always provide more meaningful default. This change will at least make sure you know what status response had when on the moment of error.